### PR TITLE
Fix return type incompatibility

### DIFF
--- a/src/models/ShippingRule.php
+++ b/src/models/ShippingRule.php
@@ -21,7 +21,7 @@ class ShippingRule extends BaseShippingRule
     // Public Methods
     // =========================================================================
 
-    public function getOptions()
+    public function getOptions(): array
     {
         return [];
     }


### PR DESCRIPTION
`craft\commerce\models\ShippingRule` is expecting an array return type on getOptions.

https://github.com/craftcms/commerce/blob/develop/src/models/ShippingRule.php#L315