### PR TITLE
Allow Order access via ModifyRatesEvent

### DIFF
--- a/src/events/ModifyRatesEvent.php
+++ b/src/events/ModifyRatesEvent.php
@@ -3,11 +3,25 @@ namespace verbb\postie\events;
 
 use yii\base\Event;
 
+use craft\commerce\elements\Order;
+
 class ModifyRatesEvent extends Event
 {
     // Properties
     // =========================================================================
 
+    /**
+     * @var array A map of rate data, each element containing an `amount` key and an `options` key with Provider-specific API data.
+     */
     public $rates = [];
+
+    /**
+     * @var array The raw API response object from the Provider.
+     */
     public $response = [];
+
+    /**
+     * @var Order The order that was used when requesting rates.
+     */
+    public $order;
 }

--- a/src/providers/AustraliaPost.php
+++ b/src/providers/AustraliaPost.php
@@ -127,6 +127,7 @@ class AustraliaPost extends Provider
             $modifyRatesEvent = new ModifyRatesEvent([
                 'rates' => $this->_rates,
                 'response' => $response,
+                'order' => $order,
             ]);
 
             if ($this->hasEventHandlers(self::EVENT_MODIFY_RATES)) {

--- a/src/providers/CanadaPost.php
+++ b/src/providers/CanadaPost.php
@@ -117,6 +117,7 @@ XML;
             $modifyRatesEvent = new ModifyRatesEvent([
                 'rates' => $this->_rates,
                 'response' => $response,
+                'order' => $order,
             ]);
 
             if ($this->hasEventHandlers(self::EVENT_MODIFY_RATES)) {

--- a/src/providers/Fastway.php
+++ b/src/providers/Fastway.php
@@ -119,6 +119,7 @@ class Fastway extends Provider
             $modifyRatesEvent = new ModifyRatesEvent([
                 'rates' => $this->_rates,
                 'response' => $response,
+                'order' => $order,
             ]);
 
             if ($this->hasEventHandlers(self::EVENT_MODIFY_RATES)) {

--- a/src/providers/FedEx.php
+++ b/src/providers/FedEx.php
@@ -218,6 +218,7 @@ class FedEx extends Provider
             $modifyRatesEvent = new ModifyRatesEvent([
                 'rates' => $this->_rates,
                 'response' => $rateReply,
+                'order' => $order,
             ]);
 
             if ($this->hasEventHandlers(self::EVENT_MODIFY_RATES)) {

--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -296,6 +296,7 @@ class UPS extends Provider
             $modifyRatesEvent = new ModifyRatesEvent([
                 'rates' => $this->_rates,
                 'response' => $rates,
+                'order' => $order,
             ]);
 
             if ($this->hasEventHandlers(self::EVENT_MODIFY_RATES)) {

--- a/src/providers/USPS.php
+++ b/src/providers/USPS.php
@@ -252,6 +252,7 @@ class USPS extends Provider
             $modifyRatesEvent = new ModifyRatesEvent([
                 'rates' => $this->_rates,
                 'response' => $response,
+                'order' => $order,
             ]);
 
             if ($this->hasEventHandlers(self::EVENT_MODIFY_RATES)) {


### PR DESCRIPTION
Should address the question in #10!

Had the codebase open, figured I'd tackle two issues at once. This one seemed pretty handy. 😉

_Edit: Seems kinda weird there isn't a Commerce event for culling/modifying matched Methods (say, `EVENT_AFTER_MATCH_METHODS`), after the fact—only to register new providers, huh?_ 🤔