### PR TITLE
Remove duplicate cakephp/utility composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "craftcms/commerce": "^2.1.0 || ^3.0.0",
         "verbb/base": "^1.0.2",
         "cakephp/core": "^3.5",
-        "cakephp/utility": "^3.3.12",
         "jeremy-dunn/php-fedex-api-wrapper": "^3.0",
         "vinceg/usps-php-api": "^1.0.0",
         "gabrielbull/ups-api": "^0.8.0",


### PR DESCRIPTION
It looks like the `cakephp/utility` package was added a second time [here](https://github.com/verbb/postie/commit/bf9cb3543d1e1cdb2a576448422b95a920265e3e) on accident. This pull request removes the old version in favor of the newer one.