### PR TITLE
add $event->order parameter to function

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -73,7 +73,7 @@ class Service extends Component
             // If this is a completed order, fetch the shipping methods, but DO NOT fetch live rates.
             // This is so we can still have registered shipping methods for `order.shippingMethod.name`
             if ($event->order->isCompleted) {
-                foreach ($provider->getShippingMethods() as $shippingMethod) {
+                foreach ($provider->getShippingMethods($event->order) as $shippingMethod) {
                     $shippingMethod->rate = 0;
                     $shippingMethod->rateOptions = [];
 


### PR DESCRIPTION
I received the following error when viewing an order in the admin.

```
ArgumentCountErrorGET /admin/commerce/orders/186412
Too few arguments to function verbb\postie\base\Provider::getShippingMethods(), 0 passed
```

This seems to have fixed it, but not sure if it will affect anything else. 