### PR TITLE
Apply the amended payload

### DIFF
--- a/src/base/Provider.php
+++ b/src/base/Provider.php
@@ -609,6 +609,9 @@ abstract class Provider extends SavableComponent implements ProviderInterface
             $this->trigger(self::EVENT_MODIFY_PAYLOAD, $event);
         }
 
+        // Apply the amended payload
+        $payload = $event->payload;
+
         self::log($this, Craft::t('postie', 'Sending payload: `{json}`.', [
             'json' => Json::encode($payload),
         ]));


### PR DESCRIPTION
When amending a payload via the `EVENT_MODIFY_PAYLOAD` event the new object was not being applied to the payload passed by reference, however the new data was being logged. This led to some confusion when debugging.