### PR TITLE
Add `beforeRegisterShippingMethods` event for modying the master list of shipping methods before handing off to Commerce.

### DIFF
--- a/src/base/PluginTrait.php
+++ b/src/base/PluginTrait.php
@@ -7,7 +7,6 @@ use verbb\postie\services\ProviderCache;
 use verbb\postie\services\Service;
 
 use Craft;
-use craft\log\FileTarget;
 
 use yii\log\Logger;
 
@@ -18,23 +17,26 @@ trait PluginTrait
     // Static Properties
     // =========================================================================
 
+	/**
+	 * @var Postie
+	 */
     public static $plugin;
 
 
     // Public Methods
     // =========================================================================
 
-    public function getProviders()
+    public function getProviders(): Providers
     {
         return $this->get('providers');
     }
 
-    public function getProviderCache()
+    public function getProviderCache(): ProviderCache
     {
         return $this->get('providerCache');
     }
 
-    public function getService()
+    public function getService(): Service
     {
         return $this->get('service');
     }


### PR DESCRIPTION
Per #67...

The `modifyShippingMethods` event currently implemented in each `Provider` only allows modification of the individual provider's _potential_ methods, _before_ the methods are hydrated with price info from the Rates.

We need a way to modify the final collection of shipping methods from Postie, before they get registered with Commerce, but _after_ they have prices assigned.

This way, we can make modifications that are conditional upon comparisons between all the available shipping rates.

Pretty please... 🙏🏼 