### PR TITLE
Check discounts and free shipping when getting line items used in fetching rates

### DIFF
--- a/src/helpers/PostieHelper.php
+++ b/src/helpers/PostieHelper.php
@@ -80,7 +80,6 @@ class PostieHelper
 
             $freeShippingFlagOnProduct = $item->purchasable->hasFreeShipping();
             $shippable = Commerce::getInstance()->getPurchasables()->isPurchasableShippable($item->getPurchasable());
-
             if (!$freeShippingFlagOnProduct && !$hasFreeShippingFromDiscount && $shippable) {
                 $items[] = $item;
             }


### PR DESCRIPTION
https://github.com/verbb/postie/issues/104

Unfortunately the change i suggested wasn't the full picture, apologies. It works for the reproduction I'd given, but not for discounts with "free shipping for matching line items". 
![image](https://github.com/verbb/postie/assets/63968092/d349da52-fb9b-419e-91d0-804deb5525a6)

In Commerce, their shipping adjustments look up discounts and filters any line items that match those discounts. https://github.com/craftcms/commerce/blob/fd56ea73faea66bb8d4f09bbd99fb7e33f0ff371/src/adjusters/Shipping.php#L113-L133

In our use case, our client wants to create a discount with free shipping matching line items in a certain category/purchasable. Commerce already supports this out of the box.

To test this, I created 2 products. Then I created a discount that will match on line item for only one of those products and give it free shipping. This means that one product will have free shipping and the other will not. 
