### PR TITLE
Shipping Number is required by Ups

### DIFF
--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -173,7 +173,7 @@ class UPS extends Provider
             'TT_S_EU_TO_OTHER_STANDARD' => 'UPS Standard',
         ];
     }
-
+    
 
     // Properties
     // =========================================================================

--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -409,8 +409,8 @@ class UPS extends Provider
 
             // Check for negotiated rates
             if ($this->getSetting('accountNumber')) {
-                $payload['RateRequest']['Shipment']['Shipper']['ShipperNumber'] = $this->accountNumber;
-
+                $payload['RateRequest']['Shipment']['Shipper']['ShipperNumber'] = $this->accountNumber
+                
                 $payload['RateRequest']['Shipment']['ShipmentRatingOptions'] = [
                     'NegotiatedRatesIndicator' => 'Y',
                 ];

--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -173,7 +173,7 @@ class UPS extends Provider
             'TT_S_EU_TO_OTHER_STANDARD' => 'UPS Standard',
         ];
     }
-    
+
 
     // Properties
     // =========================================================================
@@ -379,6 +379,7 @@ class UPS extends Provider
                     ],
                     'Shipment' => [
                         'Shipper' => [
+                            'ShipperNumber' => $this->getSetting('accountNumber'),
                             'Address' => [
                                 'City' => $storeLocation->locality ?? '',
                                 'StateProvinceCode' => $storeLocation->administrativeArea ?? '',
@@ -409,7 +410,7 @@ class UPS extends Provider
             // Check for negotiated rates
             if ($this->getSetting('accountNumber')) {
                 $payload['RateRequest']['Shipment']['Shipper']['ShipperNumber'] = $this->accountNumber;
-                
+
                 $payload['RateRequest']['Shipment']['ShipmentRatingOptions'] = [
                     'NegotiatedRatesIndicator' => 'Y',
                 ];

--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -403,14 +403,14 @@ class UPS extends Provider
                                 'CountryCode' => $order->shippingAddress->countryCode ?? '',
                             ],
                         ],
-                    ],
+                         ],
                 ],
             ];
 
             // Check for negotiated rates
             if ($this->getSetting('accountNumber')) {
-                $payload['RateRequest']['Shipment']['Shipper']['ShipperNumber'] = $this->accountNumber
-                
+                $payload['RateRequest']['Shipment']['Shipper']['ShipperNumber'] = $this->accountNumber;
+
                 $payload['RateRequest']['Shipment']['ShipmentRatingOptions'] = [
                     'NegotiatedRatesIndicator' => 'Y',
                 ];

--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -403,14 +403,14 @@ class UPS extends Provider
                                 'CountryCode' => $order->shippingAddress->countryCode ?? '',
                             ],
                         ],
-                         ],
+                    ],
                 ],
             ];
 
             // Check for negotiated rates
             if ($this->getSetting('accountNumber')) {
                 $payload['RateRequest']['Shipment']['Shipper']['ShipperNumber'] = $this->accountNumber;
-
+                
                 $payload['RateRequest']['Shipment']['ShipmentRatingOptions'] = [
                     'NegotiatedRatesIndicator' => 'Y',
                 ];


### PR DESCRIPTION
So, ups stopped working when I updated to 3.1.1 with oauth. Figured out the problem was that the shipping account number was removed. Reading it back in solved my issue. Any feedback on why this got removed?