### PR TITLE
Added UPS Declared Value

### DIFF
--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -425,7 +425,7 @@ class UPS extends Provider
             }
 
             foreach ($packedBoxes->getSerializedPackedBoxList() as $packedBox) {
-                $payload['RateRequest']['Shipment']['Package'][] = [
+                $newPackage = [
                     'PackagingType' => [
                         'Code' => '02',
                     ],
@@ -444,6 +444,16 @@ class UPS extends Provider
                         'Weight' => (string)round($packedBox['weight'], 2),
                     ],
                 ];
+
+                if ($this->getSetting('addDeclaredValue')) {
+                    $newPackage['PackageServiceOptions'] = [
+                        'DeclaredValue' => [
+                            'CurrencyCode' => $order->currency,
+                            'MonetaryValue' => (string)$packedBox['price'],
+                        ],
+                    ];
+                }
+                $payload['RateRequest']['Shipment']['Package'][] = $newPackage;
             }
 
             $this->beforeSendPayload($this, $payload, $order);

--- a/src/templates/providers/ups.html
+++ b/src/templates/providers/ups.html
@@ -64,3 +64,12 @@
     options: provider.getPickupTypeOptions(),
     warning: macros.configWarning('providers.' ~ provider.handle ~ '.settings.pickupType', 'postie'),
 }) }}
+
+{{ forms.lightswitchField({
+    label: 'Add Declared Value' | t('postie'),
+    instructions: 'Includes the line item prices as a declared value for insurance.' | t('postie', { name: provider.displayName() }),
+    id: 'addDeclaredValue',
+    name: 'addDeclaredValue',
+    on: provider.settings.addDeclaredValue ?? false,
+    warning: macros.configWarning('providers.' ~ provider.handle ~ '.settings.addDeclaredValue', 'postie'),
+}) }}


### PR DESCRIPTION
I have a client that ships a lot of expensive products. They declare the value when they ship and asked if they could have the same for their website.

I didn't see anywhere where the items in each box were totaled, and it didn't seem that the box packer had a hook to include that. So I edited the packed box list that was being sent to the UPS provider.

I also added a toggle to activate it, and made it disabled by default.