### PR TITLE
Allow Provider::EVENT_BEFORE_PACK_ORDER to override $packer

### DIFF
--- a/docs/developers/events.md
+++ b/docs/developers/events.md
@@ -84,6 +84,16 @@ Event::on(USPS::class, Provider::EVENT_BEFORE_PACK_ORDER, function(PackOrderEven
 });
 ```
 
+It is also possible to override `packer` with your own class that extends `DVDoug\BoxPacker\Packer`.
+
+```
+Event::on(USPS::class, Provider::EVENT_BEFORE_PACK_ORDER, function (PackOrderEvent $event) {
+    // Use your own custom packer class
+    $event->packer = new CustomPacker();
+});
+```
+
+
 ### The `afterPackOrder` event
 Plugins can get notified after the order contents are packed in boxes.
 

--- a/src/base/Provider.php
+++ b/src/base/Provider.php
@@ -766,6 +766,9 @@ abstract class Provider extends SavableComponent implements ProviderInterface
 
         if ($this->hasEventHandlers(self::EVENT_BEFORE_PACK_ORDER)) {
             $this->trigger(self::EVENT_BEFORE_PACK_ORDER, $packOrderEvent);
+
+            // Allow event hander to override $packer
+            $packer = $packOrderEvent->packer;
         }
 
         if ($this->packingMethod === self::PACKING_SINGLE_BOX) {


### PR DESCRIPTION
### Ticket
- https://github.com/verbb/postie/issues/123

This PR allows Provider::EVENT_BEFORE_PACK_ORDER to override $packer with a custom class.

This feature is useful if you need to fully customize how boxes are packed, or overcome performance issues when a large number of items need to be packed.