### PR TITLE
Update Install.php to account for null $storeId

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -109,6 +109,15 @@ class Install extends Migration
     {
         $orderStatusService = Commerce::getInstance()->getOrderStatuses();
         $storeId = Commerce::getInstance()->getStores()->getPrimaryStore()->id ?? null;
+
+        // This means that project config hasn't been applied or Commerce hasn't fully installed. 
+        // Subsequent writes throw the following exception. 
+        //  An error occurred while executing the "verbb\postie\migrations\Install migration: 
+        // craft\commerce\services\Stores::getCurrentStore(): Return value must be of type craft\commerce\models\Store, null returned                                                                                                                                                                  
+
+        if (!$storeId) {
+            return;
+        }
         
         $statuses = [
             new OrderStatus([


### PR DESCRIPTION
- https://github.com/verbb/postie/issues/158

If project config hasn't been applied or Commerce hasn't fully installed, Install.php throws the following exception. 


```
An error occurred while executing the "verbb\postie\migrations\Install migration: 
craft\commerce\services\Stores::getCurrentStore(): Return value must be of type craft\commerce\models\Store, null returned    
```