### PR TITLE
Allow beforePackOrder to override the order in packOrder method

### DIFF
--- a/src/base/Provider.php
+++ b/src/base/Provider.php
@@ -730,6 +730,9 @@ abstract class Provider extends SavableComponent implements ProviderInterface
 
             // Allow event hander to override $packer
             $packer = $packOrderEvent->packer;
+
+            // Allow event handler to override $order
+            $order = $packOrderEvent->order;
         }
 
         // We can pass in specific line items to pack, but default to the entire order


### PR DESCRIPTION
We have a scenario where we'd like to exclude certain items from packaging so that they don't affect the rates. 

These items are based on some external logic. 

I'd like to be able to filter them out by modifying a clone of the order that is passed to the packOrder method:

```php
Event::on(
	Provider::class,
	Provider::EVENT_BEFORE_PACK_ORDER,
	static function(PackOrderEvent $event) {
		$order = clone $event->order;
		$order->setLineItems(collect($order->getLineItems())
			->filter(function(LineItem $lineItem) {
				return true; // logic here
			})
			->all()
		);
		$event->order = $order;
	}
);
```

This PR adds a line to allow event handlers override the order that is passed to the PackOrderEvent object.