### PR TITLE
Allow beforePackOrder to override the order in packOrder method

### DIFF
--- a/src/base/Provider.php
+++ b/src/base/Provider.php
@@ -736,6 +736,9 @@ abstract class Provider extends SavableComponent implements ProviderInterface
 
             // Allow event hander to override $packer
             $packer = $packOrderEvent->packer;
+
+            // Allow event handler to override $order
+            $order = $packOrderEvent->order;
         }
 
         // We can pass in specific line items to pack, but default to the entire order


### PR DESCRIPTION
Same as #160, this adds the same logic to the Craft 5 version as well.