### PR TITLE
Call parent beforeFetchRates method in UPS provider

### DIFF
--- a/src/providers/UPS.php
+++ b/src/providers/UPS.php
@@ -230,5 +230,7 @@ class UPS extends Provider
 
             }
         }
+
+        parent::beforeFetchRates($event, $order);
     }
 }


### PR DESCRIPTION
UPS::EVENT_BEFORE_FETCH_RATES was not firing due to the beforeFetchRate method not calling the parent Provider class